### PR TITLE
fix double-right-click crash

### DIFF
--- a/src/Mahi/Gui/imgui_plot.cpp
+++ b/src/Mahi/Gui/imgui_plot.cpp
@@ -786,6 +786,8 @@ void Plot(const char *label_id, PlotInterface *plot_ptr, PlotItem *items, int nI
         ImGui::SameLine();
         ImGui::Checkbox("Crosshairs", &plot.show_crosshairs);
 
+        ImGui::EndPopup();
+
     }
     PopID();
 


### PR DESCRIPTION
when double right click at the plot area, App crash.
call EndPopup() at the end of if (ImGui::BeginPopup("##Context")) scope fix it