### PR TITLE
Fix draw() ambiguity by renaming both funcitons.

### DIFF
--- a/examples/ex_conway.cpp
+++ b/examples/ex_conway.cpp
@@ -41,7 +41,7 @@ public:
     }
 
     void draw(NVGcontext* vg, float t) {
-        if (alive) {            
+        if (alive) {
             nvgBeginPath(vg);
             nvgRect(vg, pos.x, pos.y, size, size);
             nvgFillColor(vg, Tween::Linear(Colors::Black, Colors::White, t));
@@ -67,7 +67,7 @@ public:
     int age = 0;
     bool alive    = false;
     bool willLive = false;
-    Cell* left; 
+    Cell* left;
     Cell* right;
     Cell* top;
     Cell* bottom;
@@ -157,11 +157,11 @@ public:
         ImGui::End();
     }
 
-    void draw(NVGcontext* vg) override {
+    void draw_nanovg(NVGcontext* vg) override {
         float t = 0.5 + 0.5 * std::sin((float)time().as_seconds() * 0.1f);
         set_background(Tween::Linear(Colors::White, Colors::Black, t));
         for (auto& c : cells)
-            c.draw(vg,t);        
+            c.draw(vg,t);
     }
 
 public:

--- a/examples/ex_coroutines.cpp
+++ b/examples/ex_coroutines.cpp
@@ -10,7 +10,7 @@ public:
     void update() {
         // controls
         ImGui::Begin("Coroutine Demo", nullptr);
-        if (ImGui::Button("Move X")) 
+        if (ImGui::Button("Move X"))
             start_coroutine(move(0));
         ImGui::SameLine();
         if (ImGui::Button("Move Y"))
@@ -31,7 +31,7 @@ public:
         ImGui::End();
     }
 
-    void draw(NVGcontext* vg) override {
+    void draw_nanovg(NVGcontext* vg) override {
         nvgBeginPath(vg);
         nvgCircle(vg, pos.x, pos.y, 50);
         nvgFillColor(vg, col);

--- a/examples/ex_coroutines_benchmark.cpp
+++ b/examples/ex_coroutines_benchmark.cpp
@@ -63,7 +63,7 @@ struct Dot {
 
 class CoroDemo : public Application {
 public:
-    CoroDemo(Config conf) : Application(conf) { 
+    CoroDemo(Config conf) : Application(conf) {
         dots.reserve(5000);
         for (int i = 0; i < 5000; ++i)
             dots.emplace_back(*this);
@@ -85,17 +85,17 @@ public:
         ImGui::Text("%.3f FPS", ImGui::GetIO().Framerate);
         ImGui::End();
         if (!use_coros) {
-            for (auto& dot : dots) 
-                dot.animate();            
+            for (auto& dot : dots)
+                dot.animate();
         }
 
         if (!open)
             quit();
     }
 
-    void draw(NVGcontext* vg) override {
-        for (auto& dot : dots) 
-            dot.draw(vg);        
+    void draw_nanovg(NVGcontext* vg) override {
+        for (auto& dot : dots)
+            dot.draw(vg);
     }
 
     std::vector<Dot> dots;

--- a/examples/ex_gears.cpp
+++ b/examples/ex_gears.cpp
@@ -182,7 +182,7 @@ public:
         on_keyboard.connect(this, &GearsDemo::key);
     }
 
-    void update() {
+    void update() override {
         ImGui::Begin("Gears");
         ImGui::DragFloat("Rot. X", &view_rotx, 1, 0, 360);
         ImGui::DragFloat("Rot. Y", &view_roty, 1, 0, 360);
@@ -193,7 +193,7 @@ public:
         angle = speed * (float)time().as_seconds();
     }
 
-    void draw() override {
+    void draw_opengl() override {
         glPushMatrix();
         glRotatef(view_rotx, 1.0, 0.0, 0.0);
         glRotatef(view_roty, 0.0, 1.0, 0.0);

--- a/examples/ex_nvg_demo.cpp
+++ b/examples/ex_nvg_demo.cpp
@@ -23,7 +23,7 @@ using namespace mahi::util;
 
 class NvgDemo : public Application {
 public:
-    NvgDemo(Config conf) : Application(conf) { 
+    NvgDemo(Config conf) : Application(conf) {
         set_background({0.3f, 0.3f, 0.32f, 1.0f});
         loadDemoData(m_vg,&data);
     }
@@ -32,7 +32,7 @@ public:
         freeDemoData(m_vg,&data);
     }
 
-    void update() override { 
+    void update() override {
         ImGui::Begin("ImGui");
         ImGui::Text("ImGui will always be drawn on top of NanoVG");
         ImGui::Text("even if it is called first in update()");
@@ -50,13 +50,12 @@ public:
         ImGui::End();
     }
 
-    void draw(NVGcontext* vg) override {
+    void draw_nanovg(NVGcontext* vg) override {
         auto [x,y] = get_mouse_pos();
         auto [w,h] = get_window_size();
         float t = (float)time().as_seconds();
         renderDemo(vg,x,y,w,h,t,0,&data);
-        
-    }    
+    }
 
     DemoData data;
 };

--- a/examples/ex_nvg_fbo.cpp
+++ b/examples/ex_nvg_fbo.cpp
@@ -22,7 +22,7 @@ using namespace mahi::util;
 
 class FboDemo : public Application {
 public:
-    FboDemo(Config conf) : Application(conf) { 
+    FboDemo(Config conf) : Application(conf) {
         auto pxRatio = get_pixel_ratio();
 	    m_fb = nvgluCreateFramebuffer(m_vg, (int)(100*pxRatio), (int)(100*pxRatio), NVG_IMAGE_REPEATX | NVG_IMAGE_REPEATY);
         set_background({0.3f, 0.3f, 0.32f, 1.0f});
@@ -36,7 +36,7 @@ public:
         renderPattern(m_vg, m_fb, time().as_seconds(), get_pixel_ratio());
     }
 
-    void draw(NVGcontext* vg) override {
+    void draw_nanovg(NVGcontext* vg) override {
         float t = time().as_seconds();
 		if (m_fb != NULL) {
 			NVGpaint img = nvgImagePattern(vg, 0, 0, 100, 100, 0, m_fb->image, 1.0f);

--- a/examples/ex_opengl.cpp
+++ b/examples/ex_opengl.cpp
@@ -73,7 +73,7 @@ public:
         glLinkProgram(shader);
     }
 
-    void draw() override {
+    void draw_opengl() override {
         glUseProgram(shader);
         glBindVertexArray(vao);
         glDrawArrays(GL_TRIANGLES, 0, 3);

--- a/examples/ex_puzzometry.cpp
+++ b/examples/ex_puzzometry.cpp
@@ -35,9 +35,9 @@ using namespace mahi::util;
 // https://www.puzzometry.com/
 //
 // This is a rather complex example that shows several features of the Shapes
-// class, NanoVG, and coroutines. The majority of this problem is related to 
-// the solver, which you may skip over unless it interestes you. The mahi-gui 
-// related portions start around line 500. 
+// class, NanoVG, and coroutines. The majority of this problem is related to
+// the solver, which you may skip over unless it interestes you. The mahi-gui
+// related portions start around line 500.
 
 //==============================================================================
 // SOLVER IMPLEMENTATION
@@ -47,7 +47,7 @@ using namespace mahi::util;
 // a collection S of subsets of a set X, the exact cover is a subcollection S* of
 // Such that each element in X is contained in exactly one subset in S*. For
 // example, here the exact cover solution is S* = {B,D,F}, since when combined
-// there remains exactly one 1 in every column. 
+// there remains exactly one 1 in every column.
 
 //      1  2  3  4  5  6  7
 //      -------------------
@@ -55,24 +55,24 @@ using namespace mahi::util;
 // [B]  1  0  0  1  0  0  0 *
 // [C]  0  0  0  1  1  0  1
 // [D]  0  0  1  0  1  1  0 *
-// [E]  0  1  1  0  0  1  1 
+// [E]  0  1  1  0  0  1  1
 // [F]  0  1  0  0  0  0  1 *
 
 // Read More: https://en.wikipedia.org/wiki/Exact_cover
 
-// The best method for solving large exact cover problems is Donald's Knuths 
-// "Dancing Links" (DLX) approach, which works by treating the exact cover matrix as 
+// The best method for solving large exact cover problems is Donald's Knuths
+// "Dancing Links" (DLX) approach, which works by treating the exact cover matrix as
 // a double linked list instead of a matrix of ones and zeros, and then using his
-// Algorithm X to search the list for solutions. Each list node represents a 1 in 
+// Algorithm X to search the list for solutions. Each list node represents a 1 in
 // the exact cover matrix, and is linked to adjacent 1s in all four directions.
 // The gist is that we save considerable time using double link lists because we don't
-// have to iterate the entire matrix and check if an element is 0 or 1. 
+// have to iterate the entire matrix and check if an element is 0 or 1.
 // The original paper is defintely worth a read: https://arxiv.org/pdf/cs/0011047.pdf
 //
 // The most challenging part of this approach is choosing how to define and construct
 // the exact cover matrix. I will try to break down my process as simply as possible.
 //
-// First, understand that the board and pieces are just tilings of squares and octagons. 
+// First, understand that the board and pieces are just tilings of squares and octagons.
 // Rotating the board 45 degrees, we can see that all squares and octagons are equally spaced.
 //
 // .  .  .  .  .  .  .  .  S  O  .  .  .  .  .  .
@@ -122,22 +122,22 @@ using namespace mahi::util;
 // [B]  0  0  0  1  1  1  1  1  1  ...  0
 // ...
 //
-// To constrain the problem so that every piece will be in the final solution only 
+// To constrain the problem so that every piece will be in the final solution only
 // once, we can add a dummy column for each of the 14 pieces, and cover it.
-// 
+//
 //      P1 P2 P3 P4 ... P14 | 1  2  3  4  5  6  7  8  9  ...  N
 //      --------------------------------------------------------
 // [A]  1  0  0  0  ... 0   | 1  1  1  1  1  0  0  0  0  ...  0
 // [B]  1  0  0  0  ... 0   | 0  0  0  1  1  1  1  1  1  ...  0
-// ...                      | 
+// ...                      |
 // [X]  0  1  0  0  ... 0   | 0  0  0  0  0  1  1  1  1  ...  0
 // ...
 // [Z]  0  0  0  0  ... 1   | 0  0  1  1  1  1  1  0  0  ...  0
 //
-// Since each piece can have hundres to thousands of valid placements, our exact 
+// Since each piece can have hundres to thousands of valid placements, our exact
 // cover matrix will be extremely large, and so we need to construct it
-// progmatically. To do this, I first represent the board and pieces as 
-// matrices of  0s, 4s and 8s, where 0s are dead space, 4s are squares, and 8s 
+// progmatically. To do this, I first represent the board and pieces as
+// matrices of  0s, 4s and 8s, where 0s are dead space, 4s are squares, and 8s
 // are octagons (note 0s are displayed as dots here):
 //
 // 16x16 Board:
@@ -160,19 +160,19 @@ using namespace mahi::util;
 // .  .  .  .  .  .  8  .  .  .  .  .  .  .  .  .
 //
 // 3x3 Piece:    2x4 Piece:      ... and so on for all 14 pieces ...
-//                     
+//
 // 8  4  8       8  4  8  4
 // 4  8  .       .  8  4  8
 // 8  .  .
 //
 // Next, I iteratively overlay each piece in every location on the board and take
-// the difference between the board and piece values. If all values in the piece 
+// the difference between the board and piece values. If all values in the piece
 // matrix go to zero, then the piece can be placed in that location. Note that
-// we need to permutate each piece matrix (i.e. combinations of flipping and 
-// rotating) since we don't know which orientation will be the correct one. 
+// we need to permutate each piece matrix (i.e. combinations of flipping and
+// rotating) since we don't know which orientation will be the correct one.
 
 // 3x3 Piece cannot be placed here:                     // But could be placed here:
-// 
+//
 // .  .  .  .  .  .  .  .  4  8  .  .  .  .  .  .       // .  .  .  .  .  .  .  .  4  8  .  .  .  .  .  .
 // .  .  .  .  .  .  .  4  8  4  8  .  .  .  .  .       // .  .  .  .  .  .  .  4  8  4  8  .  .  .  .  .
 // .  8  4  8  .  .  4  8  4  8  4  8  .  .  .  .       // .  .  .  .  .  .  4  8  4  8  4  8  .  .  .  .
@@ -192,14 +192,14 @@ using namespace mahi::util;
 //
 // If the placement is valid, I create an entry into the exact cover matrix that
 // covers the piece's number and the board positions that it filled. Once the sparse
-// exact cover matrix is formulated, it is converted to a dense matrix representation, 
-// and passed to my DLX solver implementation. That's pretty much it! :) 
+// exact cover matrix is formulated, it is converted to a dense matrix representation,
+// and passed to my DLX solver implementation. That's pretty much it! :)
 
 //==============================================================================
 // MATRIX OPERATIONS
 //==============================================================================
 
-typedef int         Num;    
+typedef int         Num;
 typedef vector<Num> Row;    // Matrix row
 typedef vector<Row> Matrix; // 2D Matrix
 
@@ -210,7 +210,7 @@ inline size_t size(const Matrix& mat, int dim) {
     else if (dim == 1)
         return mat[0].size();
     return 0;
-} 
+}
 
 /// Makes a matrix of all zeros, size r x c
 inline Matrix zeros(size_t r, size_t c) {
@@ -263,10 +263,10 @@ inline size_t uniquePermutations(const Matrix& mat, vector<size_t>& uniquePerms,
         auto temp = mat;
         permute(temp, perm);
         if (std::find(uniqueMats.begin(), uniqueMats.end(), temp) == uniqueMats.end()) {
-            uniquePerms.push_back(perm);  
+            uniquePerms.push_back(perm);
             uniqueMats.push_back(temp);
-            numUnique++;  
-        }    
+            numUnique++;
+        }
     }
     return numUnique;
 }
@@ -355,9 +355,9 @@ struct ExactCover {
                         row.assign(numPieces + numSlots, 0);
                         row[piece] = 1;
                         if (place(uniqueMats[perm], r, c, row)) {
-                            sparse.push_back(row);  
+                            sparse.push_back(row);
                             info.push_back({piece, perm, r, c});
-                        }                     
+                        }
                     }
                 }
             }
@@ -366,11 +366,11 @@ struct ExactCover {
         numCols = size(sparse,1);
     }
 
-   
+
     bool place(const Matrix& permMat, size_t r, size_t c, Row& rowOut) {
         auto height = size(permMat,0);
         auto width  = size(permMat,1);
-        if ((r + height) > boardRows || (c + width) > boardCols) 
+        if ((r + height) > boardRows || (c + width) > boardCols)
             return false;
         else {
             for (size_t rr = 0; rr < height; ++rr) {
@@ -384,7 +384,7 @@ struct ExactCover {
                 }
             }
         }
-        return true;   
+        return true;
     }
 
     void writeToFiles() {
@@ -400,7 +400,7 @@ struct ExactCover {
         file1.close();
         file2.close();
         file3.close();
-    }    
+    }
 
     Matrix         board;
     vector<Matrix> pieces;
@@ -430,7 +430,7 @@ struct DLX {
         Cell* D    = nullptr; // pointer to down cell
         Cell* C    = nullptr; // pointer to header cell
         size_t* S  = nullptr; // pointer to cell's column size
-    };  
+    };
     /// Constructor, taking exact cover matrix in dense representation
     DLX(const Matrix& dense, size_t numCols) {
         size_t numCells = 1 + numCols;
@@ -482,8 +482,8 @@ struct DLX {
             // left/right linkage
             if (!leftMost) {
                 cell->L = cell;
-                cell->R = cell;    
-                leftMost = cell;        
+                cell->R = cell;
+                leftMost = cell;
             }
             else {
                 cell->L     = leftMost->L;
@@ -501,7 +501,7 @@ struct DLX {
     /// Chooses column with fewest cells remaining in it
     inline Cell* chooseColumn() {
         auto C = root->R->C;
-        size_t s = -1;        
+        size_t s = -1;
         for (Cell* j = root->R; j != root; j = j->R) {
             if (*j->S < s) {
                 s = *j->S;
@@ -514,7 +514,7 @@ struct DLX {
     inline void cover(Cell* C) {
         C->R->L = C->L;
         C->L->R = C->R;
-        for (Cell* i = C->D; i != C; i = i->D) {            
+        for (Cell* i = C->D; i != C; i = i->D) {
             for (Cell* j = i->R; j != i; j = j->R) {
                 j->D->U = j->U;
                 j->U->D = j->D;
@@ -523,8 +523,8 @@ struct DLX {
         }
     }
     /// Uncoverse a column cell C
-    inline void uncover(Cell* C) {        
-        for (Cell* i = C->U; i != C; i = i->U) {            
+    inline void uncover(Cell* C) {
+        for (Cell* i = C->U; i != C; i = i->U) {
             for (Cell* j = i->L; j != i; j = j->L) {
                 ++*j->S;
                 j->D->U = j;
@@ -541,23 +541,23 @@ struct DLX {
             return true;
         }
         auto C = chooseColumn();
-        cover(C);        
+        cover(C);
         for (Cell* r = C->D; r != C; r = r->D) {
-            workingSolution.push_back(r->row);  
-            operations.push_back({(size_t)r->row,true});         
-            for (Cell* j = r->R; j != r; j = j->R) 
-                cover(j->C);                
+            workingSolution.push_back(r->row);
+            operations.push_back({(size_t)r->row,true});
+            for (Cell* j = r->R; j != r; j = j->R)
+                cover(j->C);
             if (search() && !findAll)
                 return true;
             workingSolution.pop_back();
             operations.push_back({(size_t)r->row,false});
-            C = r->C;           
+            C = r->C;
             for (Cell* j = r->L; j != r; j = j->L)
-                uncover(j->C);                
+                uncover(j->C);
         }
         uncover(C);
         return false;
-    }    
+    }
 
     bool                      findAll = false; ///< find all solutions?
     vector<Cell>              cells;           ///< all root, header, and normal cells
@@ -599,20 +599,20 @@ const Matrix g_board_mat {
 /// Piece matrices
 const vector<Matrix> g_piece_mats
 {
-    {{8, 4, 8, 4}, {0, 8, 4, 8}},                                          
-    {{0, 4, 8}, {4, 8, 4}, {8, 4, 8}},                                     
-    {{8, 4, 0}, {4, 8, 4}, {8, 4, 0}},                                     
-    {{0, 4, 0}, {4, 8, 4}, {8, 4, 8}, {4, 8, 4}, {8, 4, 0}},               
+    {{8, 4, 8, 4}, {0, 8, 4, 8}},
+    {{0, 4, 8}, {4, 8, 4}, {8, 4, 8}},
+    {{8, 4, 0}, {4, 8, 4}, {8, 4, 0}},
+    {{0, 4, 0}, {4, 8, 4}, {8, 4, 8}, {4, 8, 4}, {8, 4, 0}},
     {{4, 8, 0, 0}, {8, 4, 8, 0}, {0, 8, 4, 8}, {0, 4, 8, 4}, {0, 8, 4, 0}},
-    {{4, 8, 0}, {8, 4, 8}, {0, 8, 4}},                                     
-    {{4, 0, 0, 0}, {8, 4, 0, 0}, {4, 8, 4, 0}, {0, 4, 8, 4}},              
-    {{0, 0, 0, 8, 4}, {0, 0, 8, 4, 8}, {0, 8, 4, 8, 0}, {8, 4, 0, 0, 0}},  
-    {{0, 0, 0, 4, 0}, {0, 8, 4, 8, 4}, {8, 4, 8, 4, 8}, {0, 8, 4, 8, 4}},  
-    {{0, 8, 4, 8}, {8, 4, 8, 0}, {4, 8, 4, 0}, {8, 0, 0, 0}},              
-    {{0, 4, 8}, {0, 8, 4}, {8, 4, 0}, {0, 8, 0}},                          
-    {{8, 4, 8}, {4, 8, 0}, {8, 0, 0}},                                     
-    {{4, 8, 0}, {8, 4, 8}, {4, 8, 0}, {8, 0, 0}},                          
-    {{4, 8, 0}, {8, 4, 8}, {4, 8, 0}},                                     
+    {{4, 8, 0}, {8, 4, 8}, {0, 8, 4}},
+    {{4, 0, 0, 0}, {8, 4, 0, 0}, {4, 8, 4, 0}, {0, 4, 8, 4}},
+    {{0, 0, 0, 8, 4}, {0, 0, 8, 4, 8}, {0, 8, 4, 8, 0}, {8, 4, 0, 0, 0}},
+    {{0, 0, 0, 4, 0}, {0, 8, 4, 8, 4}, {8, 4, 8, 4, 8}, {0, 8, 4, 8, 4}},
+    {{0, 8, 4, 8}, {8, 4, 8, 0}, {4, 8, 4, 0}, {8, 0, 0, 0}},
+    {{0, 4, 8}, {0, 8, 4}, {8, 4, 0}, {0, 8, 0}},
+    {{8, 4, 8}, {4, 8, 0}, {8, 0, 0}},
+    {{4, 8, 0}, {8, 4, 8}, {4, 8, 0}, {8, 0, 0}},
+    {{4, 8, 0}, {8, 4, 8}, {4, 8, 0}},
 };
 
 /// Represents a coordinate position in the Board
@@ -623,15 +623,15 @@ struct Coord {
 
 /// Solution coordinates for g_piece_mats, all in permutation 0
 const vector<Coord> g_solutions {
-    {9, 0}, 
-    {6, 1}, 
-    {5, 4}, 
-    {1, 6}, 
-    {0, 8}, 
+    {9, 0},
+    {6, 1},
+    {5, 4},
+    {1, 6},
+    {0, 8},
     {11, 3},
-    {8, 4}, 
-    {5, 5}, 
-    {7, 6}, 
+    {8, 4},
+    {5, 5},
+    {7, 6},
     {4, 10},
     {12, 5},
     {11, 8},
@@ -682,7 +682,7 @@ Shape makeShape(const Matrix& mat) {
                     shapes.push_back(sqr);
                 else if (mat[r][c] == 8)
                     shapes.push_back(oct);
-                oct.move(g_gridSize, 0);  
+                oct.move(g_gridSize, 0);
                 sqr.move(g_gridSize, 0);
             }
             oct.move(-g_gridSize * size(mat,1), g_gridSize);
@@ -709,7 +709,7 @@ Shape makeShape(const Matrix& mat) {
 class Board
 {
   public:
-  
+
     Board(Application* app) : app(app), matrix(g_board_mat), color(Grays::Gray50) {
         shape.set_point_count(4);
         shape.set_point(0, coordPosition(9,-2));
@@ -722,7 +722,7 @@ class Board
         shape.push_back_hole(hole);
     }
 
-    void draw(NVGcontext* vg) {
+    void draw_nanovg(NVGcontext* vg) {
 
         float trans[6], inv[6];
         nvgCurrentTransform(vg, trans);
@@ -791,7 +791,7 @@ class Piece : public Transformable
     }
 
     Vec2 computeOrigin(int perm) {
-        return g_gridSize * Vec2((perm == 2 || perm == 3 || perm == 4 || perm == 5) ? (float)size(matrix,1) - 1 : 0.0f, 
+        return g_gridSize * Vec2((perm == 2 || perm == 3 || perm == 4 || perm == 5) ? (float)size(matrix,1) - 1 : 0.0f,
                                  (perm == 1 || perm == 2 || perm == 5 || perm == 6) ? (float)size(matrix,0) - 1 : 0.0f);
     }
 
@@ -800,7 +800,7 @@ class Piece : public Transformable
     }
 
     void place(const Coord& new_coord, int new_perm) {
-        set_pos(coordPosition(new_coord)); 
+        set_pos(coordPosition(new_coord));
         set_origin(computeOrigin(new_perm));
         set_scale(computeScale(new_perm));
         set_rotation(computeRotation(new_perm));
@@ -830,12 +830,12 @@ class Piece : public Transformable
             set_origin( Tween::Smootherstep(startOrigin, endOrigin, t) );
             elapsedTime += (float)app->delta_time().as_seconds();
             co_yield nullptr;
-        }        
+        }
         place(to_coord, perm);
-        transitioning = false;        
+        transitioning = false;
     }
 
-    void draw(NVGcontext* vg) {
+    void draw_nanovg(NVGcontext* vg) {
 
 
         nvgTransform(vg, transform());
@@ -863,9 +863,9 @@ class Piece : public Transformable
         Vec2 br = tl + shape.bounds().size();
         nvgBeginPath(vg);
         nvgShape(vg, shape);
-        auto paint = nvgLinearGradient(vg, tl.x, tl.y, br.x, br.y, with_alpha(color,0.25f), with_alpha(color,0.5f));   
+        auto paint = nvgLinearGradient(vg, tl.x, tl.y, br.x, br.y, with_alpha(color,0.25f), with_alpha(color,0.5f));
         nvgFillPaint(vg, paint);
-        nvgFill(vg);        
+        nvgFill(vg);
         nvgStrokeColor(vg, Tween::Linear(Whites::White, color, 0.5f));
         nvgStrokeWidth(vg, hovered ? 3 : 1);
         nvgStroke(vg);
@@ -881,12 +881,12 @@ class Piece : public Transformable
 };
 
 //==============================================================================
-// PUZZOMETRY 
+// PUZZOMETRY
 //==============================================================================
 
 class Puzzometry : public Application {
 public:
-    Puzzometry(Config conf) : Application(conf), board(this), problem(g_board_mat, g_piece_mats), solver(problem.dense, problem.numCols) { 
+    Puzzometry(Config conf) : Application(conf), board(this), problem(g_board_mat, g_piece_mats), solver(problem.dense, problem.numCols) {
 
         pieces.reserve(g_piece_mats.size());
         for (size_t i = 0; i < g_piece_mats.size(); ++i) {
@@ -895,13 +895,13 @@ public:
             pieces.emplace_back(std::move(p));
         }
         // solve
-        set_vsync(false);  
+        set_vsync(false);
         nvgCreateFontMem(m_vg, "roboto-bold", Roboto_Bold_ttf, Roboto_Bold_ttf_len, 0);
-        createCheckerBoard();  
+        createCheckerBoard();
     }
 
     void createCheckerBoard() {
-        checker = nvgluCreateFramebuffer(m_vg, 16, 16, NVG_IMAGE_REPEATX | NVG_IMAGE_REPEATY);     
+        checker = nvgluCreateFramebuffer(m_vg, 16, 16, NVG_IMAGE_REPEATX | NVG_IMAGE_REPEATY);
         nvgluBindFramebuffer(checker);
         glViewport(0, 0, 16, 16);
         glClearColor(0, 0, 0, 0);
@@ -924,12 +924,12 @@ public:
     }
 
     Enumerator shuffle() {
-        stop_coroutines();    
-        animating = false;  
+        stop_coroutines();
+        animating = false;
         percent = 0;
         solver.solutions.clear();
         std::random_device rng;
-        std::mt19937 gen(rng()); 
+        std::mt19937 gen(rng());
         std::shuffle(pieces.begin(), pieces.end(), gen);
         std::vector<Matrix> matrices;
         for (auto& p : pieces) {
@@ -947,19 +947,19 @@ public:
 
     void solve() {
         Clock clk;
-        solver = DLX(problem.dense, problem.numCols); 
+        solver = DLX(problem.dense, problem.numCols);
         solver.search();
         ms_solve = clk.get_elapsed_time().as_milliseconds();
     }
 
     void update() {
         ImGui::Begin("Puzzometry");
-        if (ImGui::Button("Shuffle")) 
-            start_coroutine(shuffle());      
-        ImGui::SameLine();  
+        if (ImGui::Button("Shuffle"))
+            start_coroutine(shuffle());
+        ImGui::SameLine();
         ImGui::BeginDisabled(animating || solver.solutions.size() > 0);
-        if (ImGui::Button("Solve")) 
-            solve();        
+        if (ImGui::Button("Solve"))
+            solve();
         ImGui::EndDisabled();
         if (solver.solutions.size()) {
             ImGui::SameLine();
@@ -970,7 +970,7 @@ public:
         if (ImGui::Button("Animate"))
             start_coroutine(animateSolution());
         ImGui::SameLine();
-        ImGui::ProgressBar(percent);        
+        ImGui::ProgressBar(percent);
         static float scale = 1;
         if (ImGui::DragFloat("Animation Speed", &scale, 0.1f, 0, 100, "%.1fx"))
             set_time_scale(scale);
@@ -984,19 +984,19 @@ public:
             int c = pieces[i].coord.c;
             int p = pieces[i].perm;
             if (ImGui::SliderInt("Row",&r,0,15))
-            { 
+            {
                 pieces[i].coord.r = r;
                 pieces[i].place(pieces[i].coord, pieces[i].perm);
             }
             ImGui::SameLine();
             if (ImGui::SliderInt("Col",&c,0,15))
-            { 
+            {
                 pieces[i].coord.c = c;
                 pieces[i].place(pieces[i].coord, pieces[i].perm);
             }
             ImGui::SameLine();
             if (ImGui::SliderInt("Permutation",&p,0,7))
-            { 
+            {
                 pieces[i].perm = p;
                 pieces[i].place(pieces[i].coord, pieces[i].perm);
             }
@@ -1006,7 +1006,7 @@ public:
         ImGui::End();
     }
 
-    void draw(NVGcontext* vg) override {
+    void draw_nanovg(NVGcontext* vg) override {
         NVGpaint img = nvgImagePattern(vg, 0, 0, 16, 16, 0, checker->image, 1.0f);
         nvgBeginPath(vg);
         nvgRect(vg,0,0,800,800);

--- a/examples/ex_shapes.cpp
+++ b/examples/ex_shapes.cpp
@@ -22,7 +22,7 @@ using namespace mahi::util;
 
 class ShapeDemo : public Application {
 public:
-    ShapeDemo(const Config& cfg) : Application(cfg) { 
+    ShapeDemo(const Config& cfg) : Application(cfg) {
 
         shape = make_polygon_shape(5, 50);
         shape.set_radii(10);
@@ -50,10 +50,10 @@ public:
 
         s1.move(100,0);
         s2.move(100,0);
-        ints_shape = clip_shapes(s1,s2,ClipType::Intersection);        
+        ints_shape = clip_shapes(s1,s2,ClipType::Intersection);
     }
-    
-    void draw(NVGcontext* nvg) override {  
+
+    void draw_nanovg(NVGcontext* nvg) override {
 
         nvgTranslate(nvg, 100, 100);
         nvgFillShape(nvg, shape2, Greens::ForestGreen);
@@ -74,7 +74,7 @@ public:
             nvgFillShape(nvg, s, Reds::FireBrick);
         for (auto& s : ints_shape)
             nvgFillShape(nvg, s, Reds::FireBrick);
-    } 
+    }
 
     Shape shape;
     Shape shape2;

--- a/examples/ex_svg.cpp
+++ b/examples/ex_svg.cpp
@@ -28,7 +28,7 @@ extern std::string mahi_logo;
 
 class SvgDemo : public Application {
 public:
-    SvgDemo(Config conf) : Application(conf) { 
+    SvgDemo(Config conf) : Application(conf) {
         svg = nsvgParseFromString(mahi_logo, "px", 96);
         width = svg->width;
         height = svg->height;
@@ -110,10 +110,10 @@ public:
         svg = nullptr;
     }
 
-    void draw(NVGcontext* vg) override {
+    void draw_nanovg(NVGcontext* vg) override {
         nvgTransform(vg, transform.transform());
-        if (svg) 
-            nvgDrawSvg(vg, svg);        
+        if (svg)
+            nvgDrawSvg(vg, svg);
         else if (fb) {
             NVGpaint paint = nvgImagePattern(vg, 0, 0, width, height, 0, fb->image, 1.0f);
             nvgBeginPath(vg);

--- a/examples/ex_transparent.cpp
+++ b/examples/ex_transparent.cpp
@@ -24,7 +24,7 @@ class TransparentDemo : public Application {
 public:
     using Application::Application;
 
-    void draw(NVGcontext* nvg) override {
+    void draw_nanovg(NVGcontext* nvg) override {
         auto [w, h] = get_window_size();
         float t = (float)time().as_seconds();
         nvgBeginPath(nvg);

--- a/include/Mahi/Gui/Application.hpp
+++ b/include/Mahi/Gui/Application.hpp
@@ -142,8 +142,8 @@ public:
         util::Time t_poll;        ///< time elapsed polling input events
         util::Time t_update;      ///< time elapsed across update()
         util::Time t_coroutines;  ///< time elapsed across all coroutines
-        util::Time t_gl;          ///< time elapsed rendering raw OpenGL (i.e. inside of draw())
-        util::Time t_nvg;      ///< time elapsed rendering NanoVG (i.e. inside of draw(NVGcontext*))
+        util::Time t_gl;          ///< time elapsed rendering raw OpenGL (i.e. inside of draw_opengl())
+        util::Time t_nvg;      ///< time elapsed rendering NanoVG (i.e. inside of draw_nanovg(NVGcontext*))
         util::Time t_imgui;    ///< time elapsed rendering ImGui
         util::Time t_idle;     ///< time elapsed idling
         util::Time t_buffers;  ///< time elapsed swapping OpenGL buffers
@@ -156,9 +156,9 @@ protected:
     /// Called once per frame. For application logic and ImGui. Do not make raw OpenGL calls here.
     virtual void update() { /* nothing by default */ }
     /// Generic OpenGL drawing context, called immediately after update().
-    virtual void draw() { /* nothing by default */ }
-    /// NanoVG specific drawing context, called immediately after draw()
-    virtual void draw(NVGcontext* nvg) { /* nothing by default */ }
+    virtual void draw_opengl() { /* nothing by default */ }
+    /// NanoVG specific drawing context, called immediately after draw_opengl()
+    virtual void draw_nanovg(NVGcontext* nvg) { /* nothing by default */ }
 
 public:
     /// Emitted when the Window moves. Passes (x,y) window position pixels.

--- a/include/Mahi/Gui/Detail/Vec2.inl
+++ b/include/Mahi/Gui/Detail/Vec2.inl
@@ -78,7 +78,7 @@ inline Vec2 intersection(const Vec2& a1, const Vec2& a2, const Vec2& b1, const V
 inline bool inside_line(const Vec2& l1, const Vec2& l2,
                        const Vec2& p) {
     float crossproduct = cross(l2 - l1, p - l1);
-    if (abs(crossproduct) > 0.1)
+    if (std::abs(crossproduct) > 0.1)
         return false;
     float dotproduct = dot(l2 - l1, p - l1);
     if (dotproduct < 0)

--- a/src/Mahi/Gui/Application.cpp
+++ b/src/Mahi/Gui/Application.cpp
@@ -209,7 +209,7 @@ void Application::run() {
         /// Render OpenGL
 
         prof_clk.restart();
-        draw();
+        draw_opengl();
         prof.t_gl = prof_clk.restart();
 
         // Render NanoVG
@@ -218,7 +218,7 @@ void Application::run() {
         glfwGetWindowSize(m_window, &winWidth, &winHeight);
         float pxRatio = static_cast<float>(fbWidth) / static_cast<float>(winWidth);
         nvgBeginFrame(m_vg, static_cast<float>(winWidth), static_cast<float>(winHeight), pxRatio);
-        draw(m_vg);
+        draw_nanovg(m_vg);
         nvgEndFrame(m_vg);
         prof.t_nvg = prof_clk.restart();
 


### PR DESCRIPTION
`draw()` and `draw(NVGcontext* nvg)` do two different things and it was confusing to me at first.
I suggest changing both names to clarify what their purpose is.
I was unable to setup coroutines on my system so the affected examples are untested.

- Overloaded functions should do comparable things.
- Rename draw() to draw_opengl() and draw_nanovg() respectively.

My IDE also removed trailing whitespaces, I can rebase the changeset if you want to keep them.