### PR TITLE
Add faster custom getter overloads.

### DIFF
--- a/3rdparty/implot/implot.h
+++ b/3rdparty/implot/implot.h
@@ -351,28 +351,33 @@ IMPLOT_API void EndPlot();
 // Plots a standard 2D line plot.
 template <typename T> IMPLOT_API void PlotLine(const char* label_id, const T* values, int count, double xscale=1, double x0=0, int offset=0, int stride=sizeof(T));
 template <typename T> IMPLOT_API void PlotLine(const char* label_id, const T* xs, const T* ys, int count, int offset=0, int stride=sizeof(T));
-                      IMPLOT_API void PlotLineG(const char* label_id, ImPlotPoint (*getter)(void* data, int idx), void* data, int count, int offset=0);
+                      IMPLOT_API void PlotLineG(const char* label_id, ImPlotPoint (*getter)(void* data, int idx), void* data, int count, int offset);
+                      IMPLOT_API void PlotLineG(const char* label_id, ImPlotPoint (*getter)(void* data, int idx), void* data, int count);
 
 // Plots a standard 2D scatter plot. Default marker is ImPlotMarker_Circle.
 template <typename T> IMPLOT_API  void PlotScatter(const char* label_id, const T* values, int count, double xscale=1, double x0=0, int offset=0, int stride=sizeof(T));
 template <typename T> IMPLOT_API  void PlotScatter(const char* label_id, const T* xs, const T* ys, int count, int offset=0, int stride=sizeof(T));
-                      IMPLOT_API  void PlotScatterG(const char* label_id, ImPlotPoint (*getter)(void* data, int idx), void* data, int count, int offset=0);
+                      IMPLOT_API  void PlotScatterG(const char* label_id, ImPlotPoint (*getter)(void* data, int idx), void* data, int count, int offset);
+                      IMPLOT_API  void PlotScatterG(const char* label_id, ImPlotPoint (*getter)(void* data, int idx), void* data, int count);
 
 // Plots a shaded (filled) region between two lines, or a line and a horizontal reference.
 template <typename T> IMPLOT_API void PlotShaded(const char* label_id, const T* values, int count, double y_ref=0, double xscale=1, double x0=0, int offset=0, int stride=sizeof(T));
 template <typename T> IMPLOT_API void PlotShaded(const char* label_id, const T* xs, const T* ys, int count, double y_ref=0, int offset=0, int stride=sizeof(T));
 template <typename T> IMPLOT_API void PlotShaded(const char* label_id, const T* xs, const T* ys1, const T* ys2, int count, int offset=0, int stride=sizeof(T));
-                      IMPLOT_API void PlotShadedG(const char* label_id, ImPlotPoint (*getter1)(void* data, int idx), void* data1, ImPlotPoint (*getter2)(void* data, int idx), void* data2, int count, int offset=0);
+                      IMPLOT_API void PlotShadedG(const char* label_id, ImPlotPoint (*getter1)(void* data, int idx), void* data1, ImPlotPoint (*getter2)(void* data, int idx), void* data2, int count, int offset);
+                      IMPLOT_API void PlotShadedG(const char* label_id, ImPlotPoint (*getter1)(void* data, int idx), void* data1, ImPlotPoint (*getter2)(void* data, int idx), void* data2, int count);
 
 // Plots a vertical bar graph. #width and #shift are in X units.
 template <typename T> IMPLOT_API void PlotBars(const char* label_id, const T* values, int count, double width=0.67, double shift=0, int offset=0, int stride=sizeof(T));
 template <typename T> IMPLOT_API void PlotBars(const char* label_id, const T* xs, const T* ys, int count, double width, int offset=0, int stride=sizeof(T));
-                      IMPLOT_API void PlotBarsG(const char* label_id, ImPlotPoint (*getter)(void* data, int idx), void* data, int count, double width, int offset=0);
+                      IMPLOT_API void PlotBarsG(const char* label_id, ImPlotPoint (*getter)(void* data, int idx), void* data, int count, double width, int offset);
+                      IMPLOT_API void PlotBarsG(const char* label_id, ImPlotPoint (*getter)(void* data, int idx), void* data, int count, double width);
 
 // Plots a horizontal bar graph. #height and #shift are in Y units.
 template <typename T> IMPLOT_API void PlotBarsH(const char* label_id, const T* values, int count, double height=0.67, double shift=0, int offset=0, int stride=sizeof(T));
 template <typename T> IMPLOT_API void PlotBarsH(const char* label_id, const T* xs, const T* ys, int count, double height, int offset=0, int stride=sizeof(T));
-                      IMPLOT_API void PlotBarsHG(const char* label_id, ImPlotPoint (*getter)(void* data, int idx), void* data, int count, double height,  int offset=0);
+                      IMPLOT_API void PlotBarsHG(const char* label_id, ImPlotPoint (*getter)(void* data, int idx), void* data, int count, double height,  int offset);
+                      IMPLOT_API void PlotBarsHG(const char* label_id, ImPlotPoint (*getter)(void* data, int idx), void* data, int count, double height);
 
 // Plots vertical error bar. The label_id should be the same as the label_id of the associated line or bar plot.
 template <typename T> IMPLOT_API void PlotErrorBars(const char* label_id, const T* xs, const T* ys, const T* err, int count, int offset=0, int stride=sizeof(T));
@@ -394,7 +399,8 @@ template <typename T> IMPLOT_API void PlotHeatmap(const char* label_id, const T*
 
 // Plots digital data. Digital plots do not respond to y drag or zoom, and are always referenced to the bottom of the plot.
 template <typename T> IMPLOT_API void PlotDigital(const char* label_id, const T* xs, const T* ys, int count, int offset=0, int stride=sizeof(T));
-                      IMPLOT_API void PlotDigitalG(const char* label_id, ImPlotPoint (*getter)(void* data, int idx), void* data, int count, int offset=0);
+                      IMPLOT_API void PlotDigitalG(const char* label_id, ImPlotPoint (*getter)(void* data, int idx), void* data, int count, int offset);
+                      IMPLOT_API void PlotDigitalG(const char* label_id, ImPlotPoint (*getter)(void* data, int idx), void* data, int count);
 
 // Plots an axis-aligned image. #bounds_min/bounds_max are in plot coordinatse (y-up) and #uv0/uv1 are in texture coordinates (y-down).
 IMPLOT_API void PlotImage(const char* label_id, ImTextureID user_texture_id, const ImPlotPoint& bounds_min, const ImPlotPoint& bounds_max, const ImVec2& uv0=ImVec2(0,0), const ImVec2& uv1=ImVec2(1,1), const ImVec4& tint_col=ImVec4(1,1,1,1));
@@ -464,7 +470,7 @@ IMPLOT_API ImPlotLimits GetPlotQuery(int y_axis = IMPLOT_AUTO);
 // Plot Tools
 //-----------------------------------------------------------------------------
 
-// Shows an annotation callout at a chosen point. 
+// Shows an annotation callout at a chosen point.
 IMPLOT_API void Annotate(double x, double y, const ImVec2& pix_offset, const char* fmt, ...)                             IM_FMTARGS(4);
 IMPLOT_API void Annotate(double x, double y, const ImVec2& pix_offset, const ImVec4& color, const char* fmt, ...)        IM_FMTARGS(5);
 // Same as above, but the annotation will always be clamped to stay inside the plot area.

--- a/3rdparty/implot/implot_items.cpp
+++ b/3rdparty/implot/implot_items.cpp
@@ -333,6 +333,20 @@ struct GetterFuncPtr {
     const int Offset;
 };
 
+struct GetterFuncPtrFast {
+    GetterFuncPtrFast(ImPlotPoint (*getter)(void* data, int idx), void* data, int count) :
+        Getter(getter),
+        Data(data),
+        Count(count)
+    { }
+    inline ImPlotPoint operator()(int idx) const {
+        return Getter(Data, idx);
+    }
+    ImPlotPoint (* const Getter)(void* data, int idx);
+    void* const Data;
+    const int Count;
+};
+
 template <typename T>
 struct GetterBarV {
     const T* Ys; double XShift; int Count; int Offset; int Stride;
@@ -893,7 +907,11 @@ template IMPLOT_API void PlotLine<double>(const char* label_id, const double* xs
 
 // custom
 void PlotLineG(const char* label_id, ImPlotPoint (*getter_func)(void* data, int idx), void* data, int count, int offset) {
-    GetterFuncPtr getter(getter_func,data, count, offset);
+    GetterFuncPtr getter(getter_func, data, count, offset);
+    return PlotLineEx(label_id, getter);
+}
+void PlotLineG(const char* label_id, ImPlotPoint (*getter_func)(void* data, int idx), void* data, int count) {
+    GetterFuncPtrFast getter(getter_func, data, count);
     return PlotLineEx(label_id, getter);
 }
 
@@ -964,7 +982,11 @@ template IMPLOT_API void PlotScatter<double>(const char* label_id, const double*
 
 // custom
 void PlotScatterG(const char* label_id, ImPlotPoint (*getter_func)(void* data, int idx), void* data, int count, int offset) {
-    GetterFuncPtr getter(getter_func,data, count, offset);
+    GetterFuncPtr getter(getter_func, data, count, offset);
+    return PlotScatterEx(label_id, getter);
+}
+void PlotScatterG(const char* label_id, ImPlotPoint (*getter_func)(void* data, int idx), void* data, int count) {
+    GetterFuncPtrFast getter(getter_func, data, count);
     return PlotScatterEx(label_id, getter);
 }
 
@@ -1137,6 +1159,10 @@ void PlotBarsG(const char* label_id, ImPlotPoint (*getter_func)(void* data, int 
     GetterFuncPtr getter(getter_func, data, count, offset);
     PlotBarsEx(label_id, getter, width);
 }
+void PlotBarsG(const char* label_id, ImPlotPoint (*getter_func)(void* data, int idx), void* data, int count, double width) {
+    GetterFuncPtrFast getter(getter_func, data, count);
+    PlotBarsEx(label_id, getter, width);
+}
 
 //-----------------------------------------------------------------------------
 // PLOT BAR H
@@ -1214,6 +1240,10 @@ template IMPLOT_API void PlotBarsH<double>(const char* label_id, const double* x
 // custom
 void PlotBarsHG(const char* label_id, ImPlotPoint (*getter_func)(void* data, int idx), void* data, int count, double height,  int offset) {
     GetterFuncPtr getter(getter_func, data, count, offset);
+    PlotBarsHEx(label_id, getter, height);
+}
+void PlotBarsHG(const char* label_id, ImPlotPoint (*getter_func)(void* data, int idx), void* data, int count, double height) {
+    GetterFuncPtrFast getter(getter_func, data, count);
     PlotBarsHEx(label_id, getter, height);
 }
 
@@ -1664,7 +1694,11 @@ template IMPLOT_API void PlotDigital<double>(const char* label_id, const double*
 
 // custom
 void PlotDigitalG(const char* label_id, ImPlotPoint (*getter_func)(void* data, int idx), void* data, int count, int offset) {
-    GetterFuncPtr getter(getter_func,data,count,offset);
+    GetterFuncPtr getter(getter_func, data, count, offset);
+    return PlotDigitalEx(label_id, getter);
+}
+void PlotDigitalG(const char* label_id, ImPlotPoint (*getter_func)(void* data, int idx), void* data, int count) {
+    GetterFuncPtrFast getter(getter_func, data, count);
     return PlotDigitalEx(label_id, getter);
 }
 
@@ -1709,7 +1743,11 @@ void PlotRects(const char* label_id, const double* xs, const double* ys, int cou
 
 // custom
 void PlotRects(const char* label_id, ImPlotPoint (*getter_func)(void* data, int idx), void* data, int count, int offset) {
-    GetterFuncPtr getter(getter_func,data,count,offset);
+    GetterFuncPtr getter(getter_func, data, count, offset);
+    return PlotRectsEx(label_id, getter);
+}
+void PlotRects(const char* label_id, ImPlotPoint (*getter_func)(void* data, int idx), void* data, int count) {
+    GetterFuncPtrFast getter(getter_func, data, count);
     return PlotRectsEx(label_id, getter);
 }
 


### PR DESCRIPTION
### The problem
Just indexing the data (patched out ImPosMod() with just idx) gives a 30% fps boost in the benchmark (mahi-gui) compared to the current implementation honouring offset, stride. Before ImPosMod() [was patched into it](https://github.com/epezent/implot/commit/eff8b5be43e2625245058c0d7c38d1aa71d47dda), the custom getter function version was faster.
To my testing the penalty of using a getter function versus raw array pointers (all without ImPosMod and OffsetAndStride()) is surprisingly low (I suspect because there is already a lot of function calls for drawing each data point anyways).

### ~~The~~ A Solution
One way to improve this is to add overloads without offset and stride parameters (and special getters in implot_items.cpp) for all functions. This will lead to double the amount of template instantiations though. A leaner variant would be to add overloads just for the _G functions. This also gives about 30% more fps in the plots benchmark.

If you have a better idea how to solve this I'm happy to rebase the PR.