### PR TITLE
Remove unnecessary headers.

### DIFF
--- a/src/Mahi/Gui/Application.cpp
+++ b/src/Mahi/Gui/Application.cpp
@@ -13,10 +13,7 @@
 #include "examples/imgui_impl_glfw.h"
 #include "examples/imgui_impl_opengl3.h"
 #include "implot.h"
-#include <stdio.h>
-#include <iostream>
 #include <stdexcept>
-#include <thread>
 
 #ifdef __linux__
 #include <string.h>

--- a/src/Mahi/Gui/Color.cpp
+++ b/src/Mahi/Gui/Color.cpp
@@ -1,6 +1,5 @@
 #include <Mahi/Gui/Color.hpp>
 #include <Mahi/Util/Random.hpp>
-#include <cmath>
 #include <cstdio>
 #include <iostream>
 #include <imgui.h>

--- a/src/Mahi/Gui/Native.cpp
+++ b/src/Mahi/Gui/Native.cpp
@@ -1,9 +1,4 @@
 #include <Mahi/Gui/Native.hpp>
-#include <cstring>
-#include <ctime>
-#include <iomanip>
-#include <cassert>
-#include <sstream>
 #include <iostream>
 #include <algorithm>
 
@@ -13,15 +8,6 @@
 #include <tchar.h>
 #include <windows.h>
 #else
-#include <errno.h>
-#include <pthread.h>
-#include <sched.h>
-#include <sys/stat.h>
-#include <sys/syscall.h>
-#include <time.h>
-#include <unistd.h>
-#include <errno.h>
-#include <sys/sysctl.h>
 #endif
 
 // TODO: We need a more robust way to detect where fs may be...


### PR DESCRIPTION
At least on Linux these headers are not used and throw warnings.
I'm sorry but I don't know if one of them is required on Mac or Windows.

Note:
`sys/sysctl.h` is deprecated on modern linux systems. And is also included in [Mahi/Util/System.cpp#L21](https://github.com/mahilab/mahi-util/blob/master/src/Mahi/Util/System.cpp#L21)