### PR TITLE
Make OpenGL forward compatibility configurable.

### DIFF
--- a/include/Mahi/Gui/Application.hpp
+++ b/include/Mahi/Gui/Application.hpp
@@ -29,8 +29,8 @@
 #include <Mahi/Gui/Coroutine.hpp>
 #endif
 
-struct ImGuiContext;  
-struct ImPlotContext; 
+struct ImGuiContext;
+struct ImPlotContext;
 
 namespace mahi {
 namespace gui {
@@ -40,20 +40,21 @@ class Application {
 public:
     /// Application Configuration options (for advanced Application construction)
     struct Config {
-        std::string title = "mahi-gui";    ///< window title
-        int  width        = 640;           ///< window width in pixels
-        int  height       = 480;           ///< window height in pixels
-        int  monitor      = 0;             ///< monitor the window will be on
-        bool fullscreen   = false;         ///< should the window be fullscreen?
-        bool resizable    = true;          ///< should the window be resizable?
-        bool visible      = true;          ///< should the window be visible?
-        bool decorated    = true;          ///< should the window have a title bar, close button, etc.?
-        bool transparent  = false;         ///< should the window area be transparent?
-        bool center       = true;          ///< should the window be centered to the monitor?
-        int  msaa         = 4;             ///< multisample anti-aliasing level (0 = none, 2, 4, 8, etc.)
-        bool nvg_aa       = true;          ///< should NanoVG use anti-aliasing?
-        bool vsync        = true;          ///< should VSync be enabled?
-        Color background  = {0, 0, 0, 1};  ///< OpenGL clear color, i.e. window background color
+        std::string title      = "mahi-gui"; ///< window title
+        int  width             = 640;        ///< window width in pixels
+        int  height            = 480;        ///< window height in pixels
+        int  monitor           = 0;          ///< monitor the window will be on
+        bool fullscreen        = false;      ///< should the window be fullscreen?
+        bool resizable         = true;       ///< should the window be resizable?
+        bool visible           = true;       ///< should the window be visible?
+        bool decorated         = true;       ///< should the window have a title bar, close button, etc.?
+        bool transparent       = false;      ///< should the window area be transparent?
+        bool center            = true;       ///< should the window be centered to the monitor?
+        int  msaa              = 4;          ///< multisample anti-aliasing level (0 = none, 2, 4, 8, etc.)
+        bool nvg_aa            = true;       ///< should NanoVG use anti-aliasing?
+        bool vsync             = true;       ///< should VSync be enabled?
+        bool gl_forward_compat = true;       ///< should GLFW_OPENGL_FORWARD_COMPAT be set? Always set on Mac.
+        Color background  = {0, 0, 0, 1};    ///< OpenGL clear color, i.e. window background color
     };
 
     /// Hidden Main Window Constructor (for using ImGui windows exclusively)

--- a/src/Mahi/Gui/Application.cpp
+++ b/src/Mahi/Gui/Application.cpp
@@ -36,7 +36,7 @@ namespace gui {
 
 namespace {
 // GLFW
-static void glfw_context_version();
+static void glfw_context_version(bool gl_forward_compat);
 static void glfw_setup_window_callbacks(GLFWwindow *window, void *userPointer);
 static void glfw_error_callback(int error, const char *description);
 static void glfw_pos_callback(GLFWwindow *window, int xpos, int ypos);
@@ -75,7 +75,7 @@ Application::Application(const Config &conf) :
         throw std::runtime_error(err_msg);
     }
     // setup GLFW context version
-    glfw_context_version();
+    glfw_context_version(conf.gl_forward_compat);
     // GLFW window hints
     glfwWindowHint(GLFW_RESIZABLE, conf.resizable);
     glfwWindowHint(GLFW_VISIBLE, conf.visible);
@@ -146,17 +146,17 @@ Application::Application(const Config &conf) :
 }
 
 Application::Application() :
-    Application(Config(
-        {"", 100, 100, 0, false, true, false, true, false, false, 4, true, true, Grays::Black})) {}
+    Application(Config({"", 100, 100, 0, false, true, false, true, false, false, 4, true, true,
+                        true, Grays::Black})) {}
 
 Application::Application(const std::string &title, int monitor) :
     Application(Config({title, 0, 0, monitor, true, false, true, true, false, false, 4, true, true,
-                        Grays::Black})) {}
+                        true, Grays::Black})) {}
 
 Application::Application(int width, int height, const std::string &title, bool resizable,
                          int monitor) :
     Application(Config({title, width, height, monitor, false, resizable, true, true, false, true, 4,
-                        true, true, Grays::Black})) {}
+                        true, true, true, Grays::Black})) {}
 
 Application::~Application() {
     ImGui_ImplOpenGL3_Shutdown();
@@ -423,7 +423,7 @@ namespace {
 // GLFW
 ///////////////////////////////////////////////////////////////////////////////
 
-static void glfw_context_version() {
+static void glfw_context_version(bool gl_forward_compat) {
     // Decide GL+GLSL versions
 #if __APPLE__
     // GL 3.2 + GLSL 150
@@ -436,7 +436,9 @@ static void glfw_context_version() {
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
     // glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);  // 3.2+ only
-    glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);            // 3.0+ only
+    if (gl_forward_compat) {
+        glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);            // 3.0+ only
+    }
 #endif
 }
 


### PR DESCRIPTION
#29 Introduced regressions for Applications that rely on legacy OpenGL features.
For example [pyglet](https://pyglet.readthedocs.io/en/latest/programming_guide/context.html).
This patch makes the forward compatibility configurable and keeps the new default to disable legacy features (although Khronos recommends to only set it for Mac)