### PR TITLE
Fix Linux build.  Remove #include <sys/sysctl.h>

### DIFF
--- a/src/Mahi/Gui/Native.cpp
+++ b/src/Mahi/Gui/Native.cpp
@@ -21,7 +21,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <errno.h>
-#include <sys/sysctl.h>
+
 #endif
 
 // TODO: We need a more robust way to detect where fs may be...


### PR DESCRIPTION
It doesn't appear that the sysctl call was used, and the call has been deprecated in Linux for some time. On Ubuntu 20.10 this include header is not found and breaks the library from building.